### PR TITLE
[PS-4592] Deprecate CloudFormation — migrated to OpenTofu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,39 +1,46 @@
+# DEPRECATED — PS-4592
+# This service has been migrated to OpenTofu/Terragrunt. The CFN stack
+# (root-login-alerts-production) is retained with DeletionPolicy: Retain on
+# all resources and is no longer managed from this Makefile. New management:
+#   ub-tf-infrastructure/infrastructure/platform-services/unbounce-production/production/us-east-1/aws-root-login-alert/
+# All CFN deploy/update/teardown targets below are commented out and must
+# not be re-enabled.
+
 .DEFAULT_GOAL := help
-.PHONY: help create-stack delete-stack status get-profile get-region get-email
-
-project.name := aws-root-login
-project.repo := github.com/unbounce/$(project.name)
-
-stack.name := root-login-alerts
-stack.owner := security
-stack.lifetime := long
+.PHONY: help
 
 help: ## show this message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-create-stack: get-profile get-region get-email ## launch the stack into AWS
-	@aws cloudformation create-stack --stack-name $(stack.name) --template-body file://template.cft --parameters ParameterKey=RecipientEmailAddress,ParameterValue=$(RECIPIENT_EMAIL) --tags Key=project,Value=$(project.name) Key=owner,Value=$(stack.owner) Key=repository,Value=$(project.repo) Key=lifetime,Value=$(stack.lifetime) --enable-termination-protection --region $(AWS_REGION) --profile $(AWS_PROFILE) --stack-policy-body file://policy.json
-
-# You must first remove stack termination protection before
-# deleting the stack, to prevent accidents.
-delete-stack: get-profile get-region ## remove the stack from AWS
-	@aws cloudformation delete-stack --stack-name $(stack.name) --region $(AWS_REGION) --profile $(AWS_PROFILE)
-
-status: get-profile get-region ## display the latest status of the stack
-	@aws cloudformation describe-stack-events --profile $(AWS_PROFILE) --region $(AWS_REGION) --stack-name $(stack.name) --query 'StackEvents[?ResourceType == `AWS::CloudFormation::Stack`] | [0].ResourceStatus'
-
-get-profile:
-ifndef AWS_PROFILE
-	@echo "Provide a AWS_PROFILE to continue."; exit 1
-endif
-
-get-region:
-ifndef AWS_REGION
-	@echo "Provide a AWS_REGION to continue."; exit 1
-endif
-
-get-email:
-ifndef RECIPIENT_EMAIL
-	@echo "Provide a RECIPIENT_EMAIL to continue."; exit 1
-endif
-
+# project.name := aws-root-login
+# project.repo := github.com/unbounce/$(project.name)
+#
+# stack.name := root-login-alerts
+# stack.owner := security
+# stack.lifetime := long
+#
+# create-stack: get-profile get-region get-email ## launch the stack into AWS
+# 	@aws cloudformation create-stack --stack-name $(stack.name) --template-body file://template.cft --parameters ParameterKey=RecipientEmailAddress,ParameterValue=$(RECIPIENT_EMAIL) --tags Key=project,Value=$(project.name) Key=owner,Value=$(stack.owner) Key=repository,Value=$(project.repo) Key=lifetime,Value=$(stack.lifetime) --enable-termination-protection --region $(AWS_REGION) --profile $(AWS_PROFILE) --stack-policy-body file://policy.json
+#
+# # You must first remove stack termination protection before
+# # deleting the stack, to prevent accidents.
+# delete-stack: get-profile get-region ## remove the stack from AWS
+# 	@aws cloudformation delete-stack --stack-name $(stack.name) --region $(AWS_REGION) --profile $(AWS_PROFILE)
+#
+# status: get-profile get-region ## display the latest status of the stack
+# 	@aws cloudformation describe-stack-events --profile $(AWS_PROFILE) --region $(AWS_REGION) --stack-name $(stack.name) --query 'StackEvents[?ResourceType == `AWS::CloudFormation::Stack`] | [0].ResourceStatus'
+#
+# get-profile:
+# ifndef AWS_PROFILE
+# 	@echo "Provide a AWS_PROFILE to continue."; exit 1
+# endif
+#
+# get-region:
+# ifndef AWS_REGION
+# 	@echo "Provide a AWS_REGION to continue."; exit 1
+# endif
+#
+# get-email:
+# ifndef RECIPIENT_EMAIL
+# 	@echo "Provide a RECIPIENT_EMAIL to continue."; exit 1
+# endif

--- a/README.md
+++ b/README.md
@@ -5,48 +5,33 @@
 ![Category-Security](https://img.shields.io/badge/Category-Security-blue.svg)
 
 Alerts when the AWS root user logs into AWS by sending an email to a
-designated email address.  This infrastructure is intended to be
-long-lived and requires no up-keep.  It should run for free or close
-to free, depending on your account usage.
+designated email address.
 
-## Requirements
+## Status — Migrated to OpenTofu/Terragrunt (PS-4592)
 
-* `make`
-* AWS CLI tool
-* Permission to create AWS resources
+This service was migrated from CloudFormation to OpenTofu/Terragrunt.
+The live CFN stack (`root-login-alerts-production`) is retained with
+`DeletionPolicy: Retain` on all resources and is **not** the source of truth
+for ongoing changes. Do not run `make create-stack` against this template.
 
-## Getting Started
-
-Run `make` to see a list of targets.
-
-## Launching the Stack
-
-The Makefile requires specific input variables to be passed in through
-the command line.  If in doubt, run the Makefile with a specific target
-and it will guide you through which variables are required.
+Active management lives in `ub-tf-infrastructure`:
 
 ```
-make create-stack AWS_PROFILE=example AWS_REGION=us-east-1 RECIPIENT_EMAIL=alerts@example.com
-{
-  "StackId": "..."
-}
+ub-tf-infrastructure/infrastructure/platform-services/unbounce-production/production/us-east-1/aws-root-login-alert/
+  sns/                          (modules/sns)
+  legacy-aws-root-login-alert/  (legacy-modules/legacy-aws-root-login-alert)
 ```
 
-The stack creation will happen asynchronously, but you can check on its
-status with `make status`.  The stack creation will pause while the
-SNS subscription is waiting for manual confirmation.  You will need
-access to the recipient email address you used in the create-stack
-command in order to confirm the SNS topic subscription and allow
-CloudFormation to proceed with the rest of the stack creation.
+The CFN template (`template.cft`), stack policy (`policy.json`), and Makefile
+deploy targets are commented out and preserved for historical reference only.
 
-## Extending This Project
+## Cross-stack export
 
-If you want to extend this project's feature set to something other than
-an email-based alert, there is no need to modify this project's template.
-This is easily done by importing the `AlertTopicArn` into another template
-through `!ImportValue` and attaching a subscription to it.
+The CFN stack still exports `root-login-alerts:sns:topic:arn`. Because the
+stack is retained, the export remains valid for any consumer using
+`!ImportValue`. New consumers should reference the SNS topic ARN through the
+Terragrunt outputs in `ub-tf-infrastructure` rather than the CFN export.
 
 ## License
 
 MIT License.  Please see [LICENSE](LICENSE) for more information.
-

--- a/policy.json
+++ b/policy.json
@@ -1,10 +1,15 @@
-{
-  "Statement": [
-    {
-      "Effect": "Deny",
-      "Action": "Update:*",
-      "Principal": "*",
-      "Resource": "*"
-    }
-  ]
-}
+# DEPRECATED — PS-4592
+# CFN stack policy is no longer applied. Service migrated to OpenTofu/Terragrunt.
+# The live stack still carries the deny-all stack policy that was set at
+# create time; this file is preserved as historical record only.
+#
+# {
+#   "Statement": [
+#     {
+#       "Effect": "Deny",
+#       "Action": "Update:*",
+#       "Principal": "*",
+#       "Resource": "*"
+#     }
+#   ]
+# }

--- a/template.cft
+++ b/template.cft
@@ -1,58 +1,65 @@
----
-AWSTemplateFormatVersion: "2010-09-09"
-Description: "Alerts when AWS root has logged into the console"
-
-Parameters:
-  RecipientEmailAddress:
-    Type: String
-    Description: "Email address that receives the alerts"
-
-Resources:
-  AlertTopic:
-    Type: "AWS::SNS::Topic"
-    Properties:
-      DisplayName: "AWS Root Login Alert"
-      Subscription:
-        - Protocol: email
-          Endpoint: !Ref RecipientEmailAddress
-  CloudwatchEventRule:
-    Type: "AWS::Events::Rule"
-    Properties:
-      Description: >
-        Watches for when the AWS root user signs into the console.
-      EventPattern:
-        detail:
-          userIdentity:
-            type:
-              - "Root"
-          eventName:
-            - "ConsoleLogin"
-          responseElements:
-            ConsoleLogin:
-              - "Success"
-      State: "ENABLED"
-      Targets:
-        - Arn: !Ref AlertTopic
-          Id: !GetAtt AlertTopic.TopicName
-  TopicPolicy:
-    Type: "AWS::SNS::TopicPolicy"
-    Properties:
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Sid: "AllowCWEToPublishAlertsToSNS"
-            Effect: "Allow"
-            Principal:
-              Service: "events.amazonaws.com"
-            Action: "sns:Publish"
-            Resource: !Ref AlertTopic
-      Topics:
-        - !Ref AlertTopic
-
-Outputs:
-  AlertTopicArn:
-    Value: !Ref AlertTopic
-    Description: "ARN of the topic that receives alerts"
-    Export:
-      Name: "root-login-alerts:sns:topic:arn"
-
+# DEPRECATED — PS-4592
+# This service has been migrated to OpenTofu/Terragrunt. The live stack
+# (root-login-alerts-production) has DeletionPolicy: Retain on all resources
+# and is kept indefinitely; this template is no longer used to deploy or
+# update it. New management lives at:
+#   ub-tf-infrastructure/infrastructure/platform-services/unbounce-production/production/us-east-1/aws-root-login-alert/
+# Do NOT re-enable any of the lines below.
+#
+# ---
+# AWSTemplateFormatVersion: "2010-09-09"
+# Description: "Alerts when AWS root has logged into the console"
+#
+# Parameters:
+#   RecipientEmailAddress:
+#     Type: String
+#     Description: "Email address that receives the alerts"
+#
+# Resources:
+#   AlertTopic:
+#     Type: "AWS::SNS::Topic"
+#     Properties:
+#       DisplayName: "AWS Root Login Alert"
+#       Subscription:
+#         - Protocol: email
+#           Endpoint: !Ref RecipientEmailAddress
+#   CloudwatchEventRule:
+#     Type: "AWS::Events::Rule"
+#     Properties:
+#       Description: >
+#         Watches for when the AWS root user signs into the console.
+#       EventPattern:
+#         detail:
+#           userIdentity:
+#             type:
+#               - "Root"
+#           eventName:
+#             - "ConsoleLogin"
+#           responseElements:
+#             ConsoleLogin:
+#               - "Success"
+#       State: "ENABLED"
+#       Targets:
+#         - Arn: !Ref AlertTopic
+#           Id: !GetAtt AlertTopic.TopicName
+#   TopicPolicy:
+#     Type: "AWS::SNS::TopicPolicy"
+#     Properties:
+#       PolicyDocument:
+#         Version: "2012-10-17"
+#         Statement:
+#           - Sid: "AllowCWEToPublishAlertsToSNS"
+#             Effect: "Allow"
+#             Principal:
+#               Service: "events.amazonaws.com"
+#             Action: "sns:Publish"
+#             Resource: !Ref AlertTopic
+#       Topics:
+#         - !Ref AlertTopic
+#
+# Outputs:
+#   AlertTopicArn:
+#     Value: !Ref AlertTopic
+#     Description: "ARN of the topic that receives alerts"
+#     Export:
+#       Name: "root-login-alerts:sns:topic:arn"


### PR DESCRIPTION
## Ticket
PS-4592: Migrate aws-root-login-alert

## Summary
The service has been migrated to OpenTofu/Terragrunt in [ub-tf-infrastructure#98](https://github.com/unbounce/ub-tf-infrastructure/pull/98) and [ub-tf-modules#135](https://github.com/unbounce/ub-tf-modules/pull/135). The live CFN stack (\`root-login-alerts-production\`) was updated via change set to add \`DeletionPolicy: Retain\` on both \`AWS::SNS::Topic\` and \`AWS::Events::Rule\`, and will be left in place indefinitely. This PR comments out the CFN deploy path in this repo so no one accidentally runs \`make create-stack\` against a live, retained-by-Tofu stack.

## Changes
- \`template.cft\` — entire file commented out with deprecation header.
- \`policy.json\` — entire file commented out; deny-all stack policy stays attached to the live stack but is no longer applied from here.
- \`Makefile\` — \`create-stack\`, \`delete-stack\`, \`status\`, and all \`get-*\` guard targets commented out. \`help\` retained.
- \`README.md\` — launch instructions replaced with migration status, Terragrunt path, and note about the retained \`root-login-alerts:sns:topic:arn\` cross-stack export.

## Verification
- Live stack template now contains \`DeletionPolicy: Retain\` on both resources (verified via \`aws cloudformation get-template\`).
- No file in this repo is referenced by CI/CD (no GitHub Actions workflow consumes \`template.cft\` or \`Makefile\`).